### PR TITLE
fix pylint error

### DIFF
--- a/ncolony/client/heart.py
+++ b/ncolony/client/heart.py
@@ -40,11 +40,11 @@ def makeService():
     """
     configJSON = os.environ.get('NCOLONY_CONFIG')
     if configJSON is None:
-        return
+        return None
     config = json.loads(configJSON)
     params = config.get('ncolony.beatcheck')
     if params is None:
-        return
+        return None
     myFilePath = filepath.FilePath(params['status'])
     if myFilePath.isdir():
         name = os.environ['NCOLONY_NAME']

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ toxworkdir = {toxinidir}/build/.tox
 [testenv]
 deps =
     {py36,py27,pypy}-unit: coverage
-    {py27,pypy}-lint: pylint
+    {py27,pypy}-lint: pylint==1.8.1
     {py27,pypy}-lint: flake8
     {py27,pypy}-lint: incremental
     {py27,pypy}-lint: gather


### PR DESCRIPTION
We pin pylint to the current latest, and fix the current problems.

PyLint adds new issues every release -- this lets us choose when we get them instead of bitrotting.